### PR TITLE
Optimize compiler args

### DIFF
--- a/args.gn
+++ b/args.gn
@@ -2,6 +2,7 @@
 # See "gn args <out_dir> --list" for available build arguments.
 target_os="win"
 target_cpu="x64"
+is_official_build=true
 is_static_skiasharp=true
 skia_enable_fontmgr_win_gdi=false
 skia_use_dng_sdk=true
@@ -17,4 +18,4 @@ skia_use_vulkan=true
 skia_use_angle=true
 skia_enable_skottie=true
 skia_enable_gpu=true
-extra_cflags=[ "-DSKIA_C_DLL", "/MT", "/EHsc", "/Z7", "-D_HAS_AUTO_PTR_ETC=1" ]
+extra_cflags=[ "-DSKIA_C_DLL", "/MT", "/EHsc", "-D_HAS_AUTO_PTR_ETC=1" ]


### PR DESCRIPTION
Setting the [`is_official_build`](https://skia.org/docs/user/build/#is_official_build-and-third-party-dependencies) parameter to true optimizes the build, improves performance, and removes the /Z7 compiler option so that debug symbols are no longer generated. This reduces the library size to a more reasonable range. In my case, the final program size was reduced by 10 MiB.
![image](https://github.com/user-attachments/assets/374be9e0-fdd2-4697-8ec4-2d99d282bb15)
